### PR TITLE
allow strictBytes type for secret

### DIFF
--- a/fastapi_jwt_auth/config.py
+++ b/fastapi_jwt_auth/config.py
@@ -5,12 +5,13 @@ from pydantic import (
     validator,
     StrictBool,
     StrictInt,
-    StrictStr
+    StrictStr,
+    StrictBytes
 )
 
 class LoadConfig(BaseModel):
     authjwt_token_location: Optional[Sequence[StrictStr]] = {'headers'}
-    authjwt_secret_key: Optional[StrictStr] = None
+    authjwt_secret_key: Optional[Union[StrictStr,StrictBytes]] = None
     authjwt_public_key: Optional[StrictStr] = None
     authjwt_private_key: Optional[StrictStr] = None
     authjwt_algorithm: Optional[StrictStr] = "HS256"


### PR DESCRIPTION
we have a secret key that is in bytes (not utf-8 unfortunately).

PyJWT does this..

```

def force_bytes(value):
    if isinstance(value, text_type):
        return value.encode('utf-8')
    elif isinstance(value, binary_type):
        return value
    else:
        raise TypeError('Expected a string value')
```

eg it allows to use bytes for the key.

Modifying type confirms works fine.
        