### PR TITLE
make type claim optional

### DIFF
--- a/fastapi_jwt_auth/auth_jwt.py
+++ b/fastapi_jwt_auth/auth_jwt.py
@@ -614,7 +614,7 @@ class AuthJWT(AuthConfig):
         issuer = self._decode_issuer if type_token == 'access' else None
         self._verifying_token(token,issuer)
 
-        if self.get_raw_jwt(token)['type'] != type_token:
+        if 'type' in token and self.get_raw_jwt(token)['type'] != type_token:
             msg = "Only {} tokens are allowed".format(type_token)
             if type_token == 'access':
                 raise AccessTokenRequired(status_code=422,message=msg)
@@ -632,7 +632,7 @@ class AuthJWT(AuthConfig):
         :param issuer: expected issuer in the JWT
         """
         raw_token = self._verified_token(encoded_token,issuer)
-        if raw_token['type'] in self._denylist_token_checks:
+        if 'type' in raw_token and raw_token['type'] in self._denylist_token_checks:
             self._check_token_is_revoked(raw_token)
 
     def _verified_token(self,encoded_token: str, issuer: Optional[str] = None) -> Dict[str,Union[str,int,bool]]:


### PR DESCRIPTION
#45 

This PR is wrong (please decline it), but would like to raise the issue however :)

https://www.iana.org/assignments/jwt/jwt.xhtml#claims

"type" is not a reserved claim, in fact I found it hard to find (bit of a loaded keyword tho) any info about using "type" claim and could not find anything. Can it be made optional (setting perhaps?)


