### PR TITLE
Added options to configure token type claim.

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -41,3 +41,16 @@
 `authjwt_refresh_token_expires`
 :   How long an refresh token should live before it expires. This takes value `integer` *(seconds)* or
     `datetime.timedelta`, and defaults to **30 days**. Can be set to `False` to disable expiration.
+
+`authjwt_token_type_claim`
+:   Wether you want to add claim that identidies type of a token. Setting it to `False` is not recommended,
+    but it's useful for integration with other systems that use jwt. Defaults to `True`
+
+`authjwt_access_token_type`
+:   String that will be placed in type claim to identify if token is an access token. Defaults to `access`
+
+`authjwt_refresh_token_type`
+:   String that will be placed in type claim to identify if token is a refresh token. Defaults to `refresh`
+
+`authjwt_token_type_claim_name`
+:   Name of claim where type of a token is located. Defaults to `type`

--- a/fastapi_jwt_auth/auth_config.py
+++ b/fastapi_jwt_auth/auth_config.py
@@ -44,6 +44,12 @@ class AuthConfig:
     _refresh_csrf_header_name = "X-CSRF-Token"
     _csrf_methods = {'POST','PUT','PATCH','DELETE'}
 
+    # options to adjust token's type claim
+    _token_type_claim = True
+    _access_token_type = "access"
+    _refresh_token_type = "refresh"
+    _token_type_claim_name = "type"
+
     @property
     def jwt_in_cookies(self) -> bool:
         return 'cookies' in self._token_location
@@ -91,6 +97,10 @@ class AuthConfig:
             cls._access_csrf_header_name = config.authjwt_access_csrf_header_name
             cls._refresh_csrf_header_name = config.authjwt_refresh_csrf_header_name
             cls._csrf_methods = config.authjwt_csrf_methods
+            cls._token_type_claim = config.authjwt_token_type_claim
+            cls._access_token_type = config.authjwt_access_token_type
+            cls._refresh_token_type = config.authjwt_refresh_token_type
+            cls._token_type_claim_name = config.authjwt_token_type_claim_name
         except ValidationError:
             raise
         except Exception:

--- a/fastapi_jwt_auth/config.py
+++ b/fastapi_jwt_auth/config.py
@@ -43,6 +43,11 @@ class LoadConfig(BaseModel):
     authjwt_access_csrf_header_name: Optional[StrictStr] = "X-CSRF-Token"
     authjwt_refresh_csrf_header_name: Optional[StrictStr] = "X-CSRF-Token"
     authjwt_csrf_methods: Optional[Sequence[StrictStr]] = {'POST','PUT','PATCH','DELETE'}
+    # options to adjust token's type claim
+    authjwt_token_type_claim: Optional[StrictBool] = True
+    authjwt_access_token_type: Optional[StrictStr] = "access"
+    authjwt_refresh_token_type: Optional[StrictStr] = "refresh"
+    authjwt_token_type_claim_name: Optional[StrictStr] = "type"
 
     @validator('authjwt_access_token_expires')
     def validate_access_token_expires(cls, v):
@@ -79,6 +84,12 @@ class LoadConfig(BaseModel):
         if v.upper() not in {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}:
             raise ValueError("The 'authjwt_csrf_methods' must be between http request methods")
         return v.upper()
+
+    @validator('authjwt_token_type_claim_name')
+    def validate_token_type_claim_name(cls, v):
+        if v.lower() in {'iss', 'sub', 'aud', 'exp', 'nbf', 'iat', 'jti'}:
+            raise ValueError("The 'authjwt_token_type_claim_name' can not override default JWT claims")
+        return v
 
     class Config:
         min_anystr_length = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,22 @@
 import pytest
 from fastapi_jwt_auth import AuthJWT
+from fastapi_jwt_auth.config import LoadConfig
 
 @pytest.fixture(scope="module")
 def Authorize():
     return AuthJWT()
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    """
+    Resets config to default to
+    guarantee that config is unchanged after test.
+    """
+    yield
+    @AuthJWT.load_config
+    def default_conf():
+        return LoadConfig(
+            authjwt_secret_key="secret",
+            authjwt_cookie_samesite='strict',
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,10 @@ def test_default_config():
     assert AuthJWT._access_csrf_header_name == "X-CSRF-Token"
     assert AuthJWT._refresh_csrf_header_name == "X-CSRF-Token"
     assert AuthJWT._csrf_methods == {'POST','PUT','PATCH','DELETE'}
+    assert AuthJWT._token_type_claim == True
+    assert AuthJWT._access_token_type == "access"
+    assert AuthJWT._refresh_token_type == "refresh"
+    assert AuthJWT._token_type_claim_name == "type"
 
 def test_token_expired_false(Authorize):
     class TokenFalse(BaseSettings):
@@ -165,6 +169,11 @@ def test_load_env_from_outside():
         authjwt_access_csrf_header_name: str = "ACCESS-CSRF-Token"
         authjwt_refresh_csrf_header_name: str = "REFRESH-CSRF-Token"
         authjwt_csrf_methods: list = ['post']
+        # options to adjust token's type claim
+        authjwt_token_type_claim: bool = True
+        authjwt_access_token_type: str = "access"
+        authjwt_refresh_token_type: str = "refresh"
+        authjwt_token_type_claim_name: str = "type"
 
     @AuthJWT.load_config
     def get_valid_settings():
@@ -204,6 +213,11 @@ def test_load_env_from_outside():
     assert AuthJWT._access_csrf_header_name == "ACCESS-CSRF-Token"
     assert AuthJWT._refresh_csrf_header_name == "REFRESH-CSRF-Token"
     assert AuthJWT._csrf_methods == ['POST']
+    # options to adjust token's type claim
+    assert AuthJWT._token_type_claim
+    assert AuthJWT._access_token_type == "access"
+    assert AuthJWT._refresh_token_type == "refresh"
+    assert AuthJWT._token_type_claim_name == "type"
 
     with pytest.raises(TypeError,match=r"Config"):
         @AuthJWT.load_config
@@ -401,3 +415,18 @@ def test_load_env_from_outside():
         @AuthJWT.load_config
         def get_invalid_csrf_methods_value():
             return [("authjwt_csrf_methods",['posts'])]
+
+    with pytest.raises(ValidationError,match=r"authjwt_token_type_claim_name"):
+        @AuthJWT.load_config
+        def get_invalid_token_type_claim_name():
+            return [("authjwt_token_type_claim_name", 'exp')]
+
+    with pytest.raises(ValidationError,match=r"authjwt_token_type_claim_name"):
+        @AuthJWT.load_config
+        def get_invalid_token_type_claim_name():
+            return [("authjwt_token_type_claim_name", 'iss')]
+
+    with pytest.raises(ValidationError,match=r"authjwt_token_type_claim_name"):
+        @AuthJWT.load_config
+        def get_invalid_token_type_claim_name():
+            return [("authjwt_token_type_claim_name", 'sub')]

--- a/tests/test_create_token.py
+++ b/tests/test_create_token.py
@@ -3,7 +3,10 @@ from fastapi_jwt_auth import AuthJWT
 from pydantic import BaseSettings
 from datetime import timedelta, datetime, timezone
 
-def test_create_access_token(Authorize):
+
+
+@pytest.fixture()
+def test_settings() -> None:
     class Settings(BaseSettings):
         AUTHJWT_SECRET_KEY: str = "testing"
         AUTHJWT_ACCESS_TOKEN_EXPIRES: int = 2
@@ -12,6 +15,8 @@ def test_create_access_token(Authorize):
     @AuthJWT.load_config
     def get_settings():
         return Settings()
+
+def test_create_access_token(Authorize, test_settings):
 
     with pytest.raises(TypeError,match=r"missing 1 required positional argument"):
         Authorize.create_access_token()
@@ -25,7 +30,7 @@ def test_create_access_token(Authorize):
     with pytest.raises(ValueError,match=r"dictionary update sequence element"):
         Authorize.create_access_token(subject=1,headers="test")
 
-def test_create_refresh_token(Authorize):
+def test_create_refresh_token(Authorize, test_settings):
     with pytest.raises(TypeError,match=r"missing 1 required positional argument"):
         Authorize.create_refresh_token()
 
@@ -35,7 +40,7 @@ def test_create_refresh_token(Authorize):
     with pytest.raises(ValueError,match=r"dictionary update sequence element"):
         Authorize.create_refresh_token(subject=1,headers="test")
 
-def test_create_dynamic_access_token_expires(Authorize):
+def test_create_dynamic_access_token_expires(Authorize, test_settings):
     expires_time = int(datetime.now(timezone.utc).timestamp()) + 90
     token = Authorize.create_access_token(subject=1,expires_time=90)
     assert jwt.decode(token,"testing",algorithms="HS256")['exp'] == expires_time
@@ -54,7 +59,7 @@ def test_create_dynamic_access_token_expires(Authorize):
     with pytest.raises(TypeError,match=r"expires_time"):
         Authorize.create_access_token(subject=1,expires_time="test")
 
-def test_create_dynamic_refresh_token_expires(Authorize):
+def test_create_dynamic_refresh_token_expires(Authorize, test_settings):
     expires_time = int(datetime.now(timezone.utc).timestamp()) + 90
     token = Authorize.create_refresh_token(subject=1,expires_time=90)
     assert jwt.decode(token,"testing",algorithms="HS256")['exp'] == expires_time
@@ -73,34 +78,34 @@ def test_create_dynamic_refresh_token_expires(Authorize):
     with pytest.raises(TypeError,match=r"expires_time"):
         Authorize.create_refresh_token(subject=1,expires_time="test")
 
-def test_create_token_invalid_type_data_audience(Authorize):
+def test_create_token_invalid_type_data_audience(Authorize, test_settings):
     with pytest.raises(TypeError,match=r"audience"):
         Authorize.create_access_token(subject=1,audience=1)
 
     with pytest.raises(TypeError,match=r"audience"):
         Authorize.create_refresh_token(subject=1,audience=1)
 
-def test_create_token_invalid_algorithm(Authorize):
+def test_create_token_invalid_algorithm(Authorize, test_settings):
     with pytest.raises(ValueError,match=r"Algorithm"):
         Authorize.create_access_token(subject=1,algorithm="test")
 
     with pytest.raises(ValueError,match=r"Algorithm"):
         Authorize.create_refresh_token(subject=1,algorithm="test")
 
-def test_create_token_invalid_type_data_algorithm(Authorize):
+def test_create_token_invalid_type_data_algorithm(Authorize, test_settings):
     with pytest.raises(TypeError,match=r"algorithm"):
         Authorize.create_access_token(subject=1,algorithm=1)
 
     with pytest.raises(TypeError,match=r"algorithm"):
         Authorize.create_refresh_token(subject=1,algorithm=1)
 
-def test_create_token_invalid_user_claims(Authorize):
+def test_create_token_invalid_user_claims(Authorize, test_settings):
     with pytest.raises(TypeError,match=r"user_claims"):
         Authorize.create_access_token(subject=1,user_claims="asd")
     with pytest.raises(TypeError,match=r"user_claims"):
         Authorize.create_refresh_token(subject=1,user_claims="asd")
 
-def test_create_valid_user_claims(Authorize):
+def test_create_valid_user_claims(Authorize, test_settings):
     access_token = Authorize.create_access_token(subject=1,user_claims={"my_access":"yeah"})
     refresh_token = Authorize.create_refresh_token(subject=1,user_claims={"my_refresh":"hello"})
 

--- a/tests/test_token_types.py
+++ b/tests/test_token_types.py
@@ -1,23 +1,15 @@
 import jwt
 import pytest
-from fastapi import Depends, FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from pydantic import BaseSettings
 
 from fastapi_jwt_auth import AuthJWT
-from fastapi_jwt_auth.exceptions import AuthJWTException
 
 
 @pytest.fixture(scope="function")
 def client() -> TestClient:
     app = FastAPI()
-
-    @app.exception_handler(AuthJWTException)
-    def authjwt_exception_handler(request: Request, exc: AuthJWTException):
-        return JSONResponse(
-            status_code=exc.status_code, content={"detail": exc.message}
-        )
 
     @app.get("/protected")
     def protected(Authorize: AuthJWT = Depends()):
@@ -51,7 +43,10 @@ def test_custom_token_type_claim_validation(
 
     # Checking that created token has custom type claim
     access = Authorize.create_access_token(subject="test")
-    assert jwt.decode(access, key="secret", algorithms=['HS256'])["custom_type"] == "access"
+    assert (
+        jwt.decode(access, key="secret", algorithms=["HS256"])["custom_type"]
+        == "access"
+    )
 
     # Checking that protected endpoint validates token correctly
     response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
@@ -60,20 +55,24 @@ def test_custom_token_type_claim_validation(
 
     # Checking that endpoint with optional protection validates token with
     # custom type claim correctly.
-    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    response = client.get(
+        "/semi_protected", headers={"Authorization": f"Bearer {access}"}
+    )
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 
-    # Creating refresh token and checking if it has correct 
+    # Creating refresh token and checking if it has correct
     # type claim.
     refresh = Authorize.create_refresh_token(subject="test")
-    assert jwt.decode(refresh, key="secret", algorithms=['HS256'])["custom_type"] == "refresh" 
+    assert (
+        jwt.decode(refresh, key="secret", algorithms=["HS256"])["custom_type"]
+        == "refresh"
+    )
 
     # Checking that refreshing with custom claim works.
     response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
-
 
 
 def test_custom_token_type_names_validation(
@@ -88,23 +87,31 @@ def test_custom_token_type_names_validation(
     def test_config():
         return TestConfig()
 
-    # Creating access token and checking that 
+    # Creating access token and checking that
     # it has custom type
     access = Authorize.create_access_token(subject="test")
-    assert jwt.decode(access, key="secret", algorithms=['HS256'])["type"] == "access_custom"
+    assert (
+        jwt.decode(access, key="secret", algorithms=["HS256"])["type"]
+        == "access_custom"
+    )
 
     # Checking that validation for custom type works as expected.
     response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 
-    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    response = client.get(
+        "/semi_protected", headers={"Authorization": f"Bearer {access}"}
+    )
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 
     # Creating refresh token and checking if it has correct type claim.
     refresh = Authorize.create_refresh_token(subject="test")
-    assert jwt.decode(refresh, key="secret", algorithms=['HS256'])["type"] == "refresh_custom" 
+    assert (
+        jwt.decode(refresh, key="secret", algorithms=["HS256"])["type"]
+        == "refresh_custom"
+    )
 
     # Checking that refreshing with custom type works.
     response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})
@@ -112,9 +119,7 @@ def test_custom_token_type_names_validation(
     assert response.json() == {"hello": "world"}
 
 
-def test_without_type_claims(
-    client: TestClient, Authorize: AuthJWT
-) -> None:
+def test_without_type_claims(client: TestClient, Authorize: AuthJWT) -> None:
     class TestConfig(BaseSettings):
         authjwt_secret_key: str = "secret"
         authjwt_token_type_claim: bool = False
@@ -125,19 +130,21 @@ def test_without_type_claims(
 
     # Creating access token and checking if it doesn't have type claim.
     access = Authorize.create_access_token(subject="test")
-    assert "type" not in jwt.decode(access, key="secret", algorithms=['HS256'])
+    assert "type" not in jwt.decode(access, key="secret", algorithms=["HS256"])
 
     response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 
-    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    response = client.get(
+        "/semi_protected", headers={"Authorization": f"Bearer {access}"}
+    )
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 
     # Creating refresh token and checking if it doesn't have type claim.
     refresh = Authorize.create_refresh_token(subject="test")
-    assert "type" not in jwt.decode(refresh, key="secret", algorithms=['HS256']) 
+    assert "type" not in jwt.decode(refresh, key="secret", algorithms=["HS256"])
 
     # Checking that refreshing without type works.
     response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})

--- a/tests/test_token_types.py
+++ b/tests/test_token_types.py
@@ -1,0 +1,145 @@
+import jwt
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from pydantic import BaseSettings
+
+from fastapi_jwt_auth import AuthJWT
+from fastapi_jwt_auth.exceptions import AuthJWTException
+
+
+@pytest.fixture(scope="function")
+def client() -> TestClient:
+    app = FastAPI()
+
+    @app.exception_handler(AuthJWTException)
+    def authjwt_exception_handler(request: Request, exc: AuthJWTException):
+        return JSONResponse(
+            status_code=exc.status_code, content={"detail": exc.message}
+        )
+
+    @app.get("/protected")
+    def protected(Authorize: AuthJWT = Depends()):
+        Authorize.jwt_required()
+        return {"hello": "world"}
+
+    @app.get("/semi_protected")
+    def protected(Authorize: AuthJWT = Depends()):
+        Authorize.jwt_optional()
+        return {"hello": "world"}
+
+    @app.get("/refresh")
+    def refresher(Authorize: AuthJWT = Depends()):
+        Authorize.jwt_refresh_token_required()
+        return {"hello": "world"}
+
+    client = TestClient(app)
+    return client
+
+
+def test_custom_token_type_claim_validation(
+    client: TestClient, Authorize: AuthJWT
+) -> None:
+    class TestConfig(BaseSettings):
+        authjwt_secret_key: str = "secret"
+        authjwt_token_type_claim_name: str = "custom_type"
+
+    @AuthJWT.load_config
+    def test_config():
+        return TestConfig()
+
+    # Checking that created token has custom type claim
+    access = Authorize.create_access_token(subject="test")
+    assert jwt.decode(access, key="secret", algorithms=['HS256'])["custom_type"] == "access"
+
+    # Checking that protected endpoint validates token correctly
+    response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    # Checking that endpoint with optional protection validates token with
+    # custom type claim correctly.
+    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    # Creating refresh token and checking if it has correct 
+    # type claim.
+    refresh = Authorize.create_refresh_token(subject="test")
+    assert jwt.decode(refresh, key="secret", algorithms=['HS256'])["custom_type"] == "refresh" 
+
+    # Checking that refreshing with custom claim works.
+    response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+
+
+def test_custom_token_type_names_validation(
+    client: TestClient, Authorize: AuthJWT
+) -> None:
+    class TestConfig(BaseSettings):
+        authjwt_secret_key: str = "secret"
+        authjwt_refresh_token_type: str = "refresh_custom"
+        authjwt_access_token_type: str = "access_custom"
+
+    @AuthJWT.load_config
+    def test_config():
+        return TestConfig()
+
+    # Creating access token and checking that 
+    # it has custom type
+    access = Authorize.create_access_token(subject="test")
+    assert jwt.decode(access, key="secret", algorithms=['HS256'])["type"] == "access_custom"
+
+    # Checking that validation for custom type works as expected.
+    response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    # Creating refresh token and checking if it has correct type claim.
+    refresh = Authorize.create_refresh_token(subject="test")
+    assert jwt.decode(refresh, key="secret", algorithms=['HS256'])["type"] == "refresh_custom" 
+
+    # Checking that refreshing with custom type works.
+    response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+
+def test_without_type_claims(
+    client: TestClient, Authorize: AuthJWT
+) -> None:
+    class TestConfig(BaseSettings):
+        authjwt_secret_key: str = "secret"
+        authjwt_token_type_claim: bool = False
+
+    @AuthJWT.load_config
+    def test_config():
+        return TestConfig()
+
+    # Creating access token and checking if it doesn't have type claim.
+    access = Authorize.create_access_token(subject="test")
+    assert "type" not in jwt.decode(access, key="secret", algorithms=['HS256'])
+
+    response = client.get("/protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    response = client.get("/semi_protected", headers={"Authorization": f"Bearer {access}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+    # Creating refresh token and checking if it doesn't have type claim.
+    refresh = Authorize.create_refresh_token(subject="test")
+    assert "type" not in jwt.decode(refresh, key="secret", algorithms=['HS256']) 
+
+    # Checking that refreshing without type works.
+    response = client.get("/refresh", headers={"Authorization": f"Bearer {refresh}"})
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}


### PR DESCRIPTION
Hi, you did a super cool library, but I couldn't use it in our ecosystem.

These options are here to help this library to be more generic.
In many cases services built with `FastAPI` are used as micro services that integrated in existing systems with existing authentication mechanisms.
I faced an issue that JWTs that used in our backend have custom type claims, so I added these options to be able 
to adjust this library nicely.

Signed-off-by: Pavel Kirilin <win10@list.ru>